### PR TITLE
노트 업로드(음원, 유튜브, 직접)  API 구현

### DIFF
--- a/notes/models.py
+++ b/notes/models.py
@@ -53,7 +53,9 @@ class Notes(models.Model):
     )  # 게시물 작성자 ID
     created_at = models.DateTimeField(auto_now_add=True)  # 작성 날짜
     is_updated = models.BooleanField(default=False)  # 수정 여부
-    album_art = models.CharField(max_length=200)  # 앨범 아트(유튜브 썸네일 URL)
+    album_art = models.CharField(
+        max_length=200, null=True, blank=True
+    )  # 앨범 아트(유튜브 썸네일 URL)
     song_title = models.CharField(max_length=200)  # 노래 제목(유튜브 영상 제목)
     artist = models.CharField(max_length=200)  # 아티스트 이름(유튜브 채널명)
     lyrics = models.TextField(null=True, blank=True)

--- a/uploads/models.py
+++ b/uploads/models.py
@@ -1,3 +1,7 @@
 from django.db import models
+from notes.models import Notes
 
-# Create your models here.
+"""
+class NoteUpload(models.Model):
+    note = models.ForeignKey(Notes, on_delete=models.CASCADE)  
+"""

--- a/uploads/serializers.py
+++ b/uploads/serializers.py
@@ -1,3 +1,4 @@
+import random
 from rest_framework import serializers
 from notes.models import *
 from accounts.models import *
@@ -5,43 +6,73 @@ from accounts.serializers import UserSerializer
 from datetime import datetime, timedelta
 
 
-class FunctionMixin:
+# 노트 업로드(음원)
+class Song_NotesUploadSerializer(serializers.ModelSerializer):
+    user = UserSerializer(read_only=True)
 
-    def get_author_nickname(self, obj):
-        return obj.author.nickname
+    class Meta:
+        model = Notes
+        fields = [
+            "id",
+            "user",
+            "album_art",
+            "song_title",
+            "artist",
+            "lyrics",
+            "location_name",
+            "location_address",
+            "emotion",
+            "memo",
+            "visibility",
+            "tag_time",
+            "tag_season",
+            "tag_context",
+            "created_at",
+        ]
 
-    def get_author_profile(self, obj):
-        return obj.author.profile
 
-    def get_likes_count(self, obj):
-        return obj.likes.count()
+# 노트 업로드(음원)
+class YT_NotesUploadSerializer(serializers.ModelSerializer):
+    user = UserSerializer(read_only=True)
 
-    def get_comment_count(self, obj):
-        return obj.comment.count()
+    class Meta:
+        model = Notes
+        fields = [
+            "id",
+            "user",
+            "link",
+            "album_art",
+            "song_title",
+            "artist",
+            "lyrics",
+            "location_name",
+            "location_address",
+            "emotion",
+            "memo",
+            "visibility",
+            "tag_time",
+            "tag_season",
+            "tag_context",
+            "created_at",
+        ]
 
-    def get_recomments_count(self, obj):
-        return obj.recomments.count()
 
-    def get_com_count(self, obj):
-        comment_count = obj.comment_count()
-        recomment_count = obj.recomment_count()
-
-        return comment_count + recomment_count
-
-    def get_com_likes_count(self, obj):
-        return obj.com_likes.count()
-
-    def get_com_relikes_count(self, obj):
-        return obj.com_relikes.count()
-
-    def get_is_scraped(self, obj):
-        request_user = self.context["request"].user
-        return request_user in obj.scrap.all()
+# 기본 앨범 커버 이미지 URL 리스트
+DEFAULT_ALBUM_ART_IMAGES = [
+    "https://img.freepik.com/premium-vector/white-texture-round-striped-surface-white-soft-cover_547648-928.jpg",
+    "https://images.unsplash.com/photo-1550684376-efcbd6e3f031?fm=jpg&q=60&w=3000&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8N3x8JUVBJUIyJTgwJUVDJTlEJTgwJUVDJTgzJTg5JTIwJUVCJUIwJUIwJUVBJUIyJUJEJUVEJTk5JTk0JUVCJUE5JUI0fGVufDB8fDB8fHww",
+]
 
 
 # 노트 업로드(음원)
 class NotesUploadSerializer(serializers.ModelSerializer):
     user = UserSerializer(read_only=True)
+
+    def create(self, validated_data):
+        # 만약 album_art 필드에 값이 없거나 비어 있다면 기본 이미지를 할당
+        if not validated_data.get("album_art"):
+            validated_data["album_art"] = random.choice(DEFAULT_ALBUM_ART_IMAGES)
+        return super().create(validated_data)
 
     class Meta:
         model = Notes

--- a/uploads/urls.py
+++ b/uploads/urls.py
@@ -4,8 +4,8 @@ from .views import *
 app_name = "uploads"
 
 urlpatterns = [
-    path("note/songs/", SongNoteUploadView.as_view()),
-    #path("note/yt/", YTNoteUploadView.as_view()),
-    #path("note/self/", NoteUploadView.as_view())
-    #path("pli/", PliUploadView.as_view())
+    path("note/", SongNoteUploadView.as_view()),  # 노트(음원)업로드
+    path("note/yt/", YTNoteUploadView.as_view()),  # 노트(유튜브)업로드
+    path("note/self/", NoteUploadView.as_view()),  # 노트(직접)업로드
+    # path("pli/", PliUploadView.as_view())
 ]

--- a/uploads/views.py
+++ b/uploads/views.py
@@ -20,7 +20,7 @@ from notes.models import *
 # 노트 업로드(음원)
 class SongNoteUploadView(views.APIView):
     def post(self, request):
-        serializer = NotesUploadSerializer(data=request.data)
+        serializer = Song_NotesUploadSerializer(data=request.data)
         if serializer.is_valid():
             note = serializer.save(user=request.user)
             # 태그 개수 카운팅팅
@@ -46,15 +46,65 @@ class SongNoteUploadView(views.APIView):
         )
 
 
-"""
 # 노트 업로드(유튜브)
 class YTNoteUploadView(views.APIView):
-    serializer_class = 
+    def post(self, request):
+        serializer = YT_NotesUploadSerializer(data=request.data)
+        if serializer.is_valid():
+            note = serializer.save(user=request.user)
+            # 태그 개수 카운팅팅
+            if note.emotion:
+                note.emotion.count += 1
+                note.emotion.save()
+            if note.tag_time:
+                note.tag_time.count += 1
+                note.tag_time.save()
+            if note.tag_season:
+                note.tag_season.count += 1
+                note.tag_season.save()
+            if note.tag_context:
+                note.tag_context.count += 1
+                note.tag_context.save()
+            return Response(
+                {"message": "노트(유튜브) 작성 성공", "data": serializer.data},
+                status=status.HTTP_201_CREATED,
+            )
+        return Response(
+            {"message": "노트(유튜브) 작성 실패", "errors": serializer.errors},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
 
 # 노트 업로드(직접)
 class NoteUploadView(views.APIView):
-    serializer_class = 
+    def post(self, request):
+        serializer = NotesUploadSerializer(data=request.data)
+        if serializer.is_valid():
+            note = serializer.save(user=request.user)
+            # 태그 개수 카운팅팅
+            if note.emotion:
+                note.emotion.count += 1
+                note.emotion.save()
+            if note.tag_time:
+                note.tag_time.count += 1
+                note.tag_time.save()
+            if note.tag_season:
+                note.tag_season.count += 1
+                note.tag_season.save()
+            if note.tag_context:
+                note.tag_context.count += 1
+                note.tag_context.save()
+            return Response(
+                {"message": "노트(직접) 작성 성공", "data": serializer.data},
+                status=status.HTTP_201_CREATED,
+            )
+        return Response(
+            {"message": "노트(직접) 작성 실패", "errors": serializer.errors},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
 
+
+"""
 class PostAddView(views.APIView):
     serializer_class = PostSerializer
     #permission_classes = [IsAuthenticated]  


### PR DESCRIPTION
- 노트 업로드(음원) 수정
- notes/models.py 수정
- uploads 코드 수정

노트 업로드(유튜브)
<img width="556" alt="image" src="https://github.com/user-attachments/assets/40cfa4d3-cd5c-45ec-821e-6a6af8347ba3" />
노트 업로드(직접)
<img width="550" alt="image" src="https://github.com/user-attachments/assets/70187fc6-2802-420b-abf0-872340532a58" />
